### PR TITLE
Feature/debug log qr contents

### DIFF
--- a/src/__tests__/util/requiredAttributes.test.js
+++ b/src/__tests__/util/requiredAttributes.test.js
@@ -61,7 +61,7 @@ test("Construct errors", () => {
                 "error_code": "903"
             }
         ],
-        "extensions.StudyLoadExtension": [
+        "extensions.TimeInvestmentExtension": [
             {
                 "error_code": "903"
             }

--- a/src/routes/students/BadgeDetails.svelte
+++ b/src/routes/students/BadgeDetails.svelte
@@ -89,6 +89,7 @@
             showOb3SsiAgentModal = true
             loaded = true
             qrCode = res.qr_code_base64;
+            console.debug("QR code contents:", qrCode)
         })
 
     }


### PR DESCRIPTION
This adds a `console.debug()` that prints the contents of the QR code to the console, so we can easier debug the generated QR codes without having to scan them.

I saw a failing test, and found it had nothing to do with my change but an earlier one and fixed that in a separate commit when I was there anyway.