### PR TITLE
refactor: Remove duplicate and unused utility function.

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -22,7 +22,7 @@
         validatedUserName
     } from "./stores/user";
     import {role} from "./util/role";
-    import {getSocialAccount} from "./api";
+    import {getSocialAccounts} from "./api";
     import PublicBadgeClassPage from "./components/shared/PublicBadgeClassPage.svelte"
     import EnrollmentDetails from "./routes/students/EnrollmentDetails.svelte";
     import {Flash} from "./components/forms/";
@@ -58,7 +58,7 @@
         const path = window.location.pathname;
         const publicPaths = ["public", "/auth/login", "signup", "version/info", "launch/lti"]
         if (!publicPaths.some(p => path.indexOf(p) > -1)) {
-            getSocialAccount()
+            getSocialAccounts()
                 .then(res => {
                     loaded = true;
                     $userLoggedIn = true;

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -81,7 +81,7 @@ export function getSocialAccountsSafe() {
     return validFetch(path);
 }
 
-export function getSocialAccount() {
+export function getSocialAccounts() {
     const path = `${serverUrl}/user/socialaccounts`;
     return validFetchNoErrorDialog(path);
 }
@@ -108,11 +108,6 @@ export function setPrimaryEmail(emailId) {
 export function deleteEmail(emailId) {
     const path = `${serverUrl}/user/emails/${emailId}`;
     return validFetchNoErrorDialog(path, {}, "DELETE");
-}
-
-export function getSocialAccounts() {
-    const path = `${serverUrl}/user/socialaccounts`;
-    return validFetch(path);
 }
 
 export function deleteUser(entityId) {


### PR DESCRIPTION
We had both getSocialAccount() and getSocialAccounts(). They did the same. One wasn't used. Folding them together, and making it consistent with getSocialAccountsSafe().