### PR TITLE
feat: Add a link to a dev/demo wwwallet instance that we can follow to import

### DIFF
--- a/src/components/students/SsiAgentModal.svelte
+++ b/src/components/students/SsiAgentModal.svelte
@@ -1,4 +1,8 @@
 <script>
+  // This should eventually go into config.wwwalletBaseUrl. But that would require us to add
+  // configuration to the global config which is also required in production and other environments
+  // that don't use this feature at all yet. Hence we hardcode it here. For now.
+  const WWWALLET_BASE_URL = "https://wwwallet.dev.eduwallet.nl/cb/"
   import I18n from "i18n-js";
   import {Modal} from '../../components/forms';
   import QRCode from 'qrcode';
@@ -8,12 +12,21 @@
   export let walletName = "";
   export let submit;
 
+  let importWwwalletText = I18n.t("models.badge.ob3SsiAgentQRCode", {
+    name: I18n.t("models.badge.ob3SsiAgentNames.wwwallet")
+  })
+  let wwwalletLink = new URL(WWWALLET_BASE_URL);
+  let linkClass = 'disabled';
   let qrCodeDataUrl = '';
 
   $: if (offer) updateQRCode();
 
   async function updateQRCode() {
     console.debug(`Generate QR for offer: ${offer}`);
+    wwwalletLink.searchParams.set('credential_offer', offer);
+
+    linkClass = '';
+
     qrCodeDataUrl = await QRCode.toDataURL(offer);
   }
 
@@ -22,11 +35,19 @@
 <style lang="scss">
     .qr-code-container {
         display: flex;
+        flex-flow: column;
 
         img {
             width: 240px;
             height: auto;
             margin: auto;
+        }
+        a {
+            display: block;
+            margin: auto;
+        }
+        a.disabled {
+           display: none;
         }
     }
 </style>
@@ -39,6 +60,7 @@
         submitLabel={I18n.t("error.close")}>
     <div class="qr-code-container">
         <img alt="QR code" src={qrCodeDataUrl}/>
+        <a href="{wwwalletLink}" target="_blank" rel="noopener noreferrer" class="{linkClass}" title="{importWwwalletText}">{importWwwalletText}</a>
     </div>
 </Modal>
 {/if}

--- a/src/locale/en.js
+++ b/src/locale/en.js
@@ -896,6 +896,7 @@ I18n.translations.en = {
             ob3SsiAgentNames: {
                 unime: "unime",
                 sphereon: "sphereon",
+                wwwallet: "WWWallet",
             },
             ob3SsiAgentQRCode: "Import into {{name}} wallet",
             ob3SsiAgentQRCodeQuestion:

--- a/src/locale/nl.js
+++ b/src/locale/nl.js
@@ -905,6 +905,7 @@ I18n.translations.nl = {
             ob3SsiAgentNames: {
                 unime: "unime",
                 sphereon: "sphereon",
+                wwwallet: "WWWallet",
             },
             ob3SsiAgentQRCode: "Import into {{name}} wallet",
             ob3SsiAgentQRCodeQuestion:


### PR DESCRIPTION
This ads a link to a WWW wallet instance that we can follow to import a credential there.

![image](https://github.com/user-attachments/assets/3d56c82b-c125-4a6f-b467-4bb5b773914e)


* Added a hardcoded `WWWALLET_BASE_URL` for the WWWallet feature. This is a temporary measure until global configuration can be updated to add this url there. (`src/components/students/SsiAgentModal.svelte`)
* Updated the QR code generation logic to include the WWWallet link and dynamically set the link class based on the presence of an offer. (`src/components/students/SsiAgentModal.svelte`)
* Adjusted the styling to properly display the WWWallet link and hide it when disabled. (`src/components/students/SsiAgentModal.svelte`)
* Added the WWWallet link to the modal, ensuring it only appears when appropriate. (`src/components/students/SsiAgentModal.svelte`)
* Added the translation for `wwwallet` in both English and Dutch localization files.