### PR TITLE
feat: Use a link to www wallet that somewhat works.

### DIFF
--- a/src/components/students/SsiAgentModal.svelte
+++ b/src/components/students/SsiAgentModal.svelte
@@ -23,9 +23,20 @@
 
   async function updateQRCode() {
     console.debug(`Generate QR for offer: ${offer}`);
-    wwwalletLink.searchParams.set('credential_offer', offer);
 
-    linkClass = '';
+    // extract the actual URL from the offer, wwwallet cannot handle actual credential_offers yet.
+    // So only if we have this uri, can we show an import link
+    const offerURI = new URL(offer);
+    const offerURIParams = offerURI.searchParams;
+    console.debug(`params: ${offerURIParams}`);
+
+    if (offerURIParams.get("credential_offer_uri") !== null) {
+      wwwalletLink.searchParams.set('credential_offer_uri', offerURIParams.get("credential_offer_uri"));
+      linkClass = '';
+    } else {
+      linkClass = 'disabled';
+      wwwalletLink = new URL("#");
+    }
 
     qrCodeDataUrl = await QRCode.toDataURL(offer);
   }


### PR DESCRIPTION
Somehow the offer doesn't work. But passing the uri does work. We then use this.

This removes the link for the unime backend, as that offer does not have a uri in it. But it keeps the link for veramo/sphereon. 