### PR TITLE
fix: Fix import unime dialog not showing the QR code

### DIFF
--- a/src/components/students/SsiAgentModal.svelte
+++ b/src/components/students/SsiAgentModal.svelte
@@ -35,7 +35,7 @@
       linkClass = '';
     } else {
       linkClass = 'disabled';
-      wwwalletLink = new URL("#");
+      wwwalletLink = new URL("about:blank");
     }
 
     qrCodeDataUrl = await QRCode.toDataURL(offer);


### PR DESCRIPTION
The dialog crashed on creating an empty URL when unime doesn't respond with an offer with an url (the offer object). Apparently `new URL('#')` isn't allowed. We set it to about:blank for now.