### PR TITLE
fix: Correct redirect path handling to fix count queries

### DIFF
--- a/src/routes/Login.svelte
+++ b/src/routes/Login.svelte
@@ -28,7 +28,7 @@
             notificationEn, notificationNl, displayStart, displayEnd, notificationType
           }
         }`);
-        
+
         return {
           badgeInstancesCount: res.badgeInstancesCount,
           badgeClassesCount: res.badgeClassesCount,
@@ -40,9 +40,9 @@
     onMount(() => {
       const urlSearchParams = new URLSearchParams(window.location.search);
       forceLogin = urlSearchParams.has("force");
-      const currentRedirectPath = get(redirectPath);
+      const currentRedirectPath = urlSearchParams.get("redirectPath") || "";
       validateName = (urlSearchParams.get("validateName") === "true" || currentRedirectPath.includes("direct-awards"));
-      
+
       if ($userRole && $userLoggedIn) {
         navigate($redirectPath || "/");
         $redirectPath = "";


### PR DESCRIPTION
Merge conflict re-introduced some redirect-path handling that failed in ewi branch. Causing the subsequent count queries to fail.

We changed redirect handling in #178 but the merge in #200 re-introduced a line that used a now undefined variable.

This fixes https://git.ia.surfsara.nl/surf-internal/educational-logistics/edubadges/edubadges/-/issues/68

This, however, uncovered a secondary, related bug in edubadges-server. Solved in https://github.com/edubadges/edubadges-server/pull/338