### PR TITLE
feature: Make badgeClass filters persistent

### DIFF
--- a/src/locale/en.js
+++ b/src/locale/en.js
@@ -155,7 +155,6 @@ I18n.translations.en = {
     },
     backpack: {
         title: "Your edubadges",
-        showAllBadges: "you're viewing some badges - show all",
     },
     archived: {
         title: "Your archived edubadges",

--- a/src/locale/nl.js
+++ b/src/locale/nl.js
@@ -156,7 +156,6 @@ I18n.translations.nl = {
     },
     backpack: {
         title: "Behaalde edubadges",
-        showAllBadges: "je ziet een selectie - toon alles",
     },
     archived: {
         title: "Je gearchiveerde edubadges",

--- a/src/routes/students/Backpack.svelte
+++ b/src/routes/students/Backpack.svelte
@@ -1,6 +1,5 @@
 <script>
     import I18n from "i18n-js";
-    import {link} from "svelte-routing";
     import Spinner from "../../components/Spinner.svelte";
     import {onMount} from "svelte";
     import {redirectPath, userHasClosedWelcome} from "../../stores/user";
@@ -20,26 +19,29 @@
     let loaded = false;
     let badges = [];
     let view = "cards";
-    let badgeClassIds = [];
+    let filterBadgeClassIds = [];
+    const STORAGE_KEY = 'filterBadgeClassIds';
 
     const goToEduId = () => {
         $redirectPath = window.location.pathname;
         requestLoginToken(getService(role.STUDENT), true);
     };
 
-    const readBadgeClassIdsFromUrl = () => {
+    const initializeBadgeClassFilter = () => {
+        // URL params always take precedence (allows overriding)
         const urlParams = new URLSearchParams(window.location.search);
-        return urlParams.getAll('filter.badgeclass_id');
-    };
+        const urlFilter = urlParams.getAll('filter.badgeclass_id');
 
-    const handleShowAllBadges = () => {
-        badgeClassIds = [];
-        loaded = false;
-        getBadges().then((response) => {
-            badges = response.badgeInstances;
-            loaded = true;
-        });
-    }
+        if (urlFilter.length > 0) {
+            // URL has filter - use it and persist
+            filterBadgeClassIds = urlFilter;
+            localStorage.setItem(STORAGE_KEY, JSON.stringify(filterBadgeClassIds));
+        } else {
+            // No URL filter - use localStorage (persistent)
+            const stored = localStorage.getItem(STORAGE_KEY);
+            filterBadgeClassIds = stored ? JSON.parse(stored) : [];
+        }
+    };
     
     const secureQuery = `query {
       currentUser {
@@ -48,7 +50,7 @@
     }`;
 
     const getBadges = async () => {
-      return queryData(studentBadgeInstances(badgeClassIds))
+      return queryData(studentBadgeInstances(filterBadgeClassIds))
         .then((response) => {
           const directAwards = response.directAwards || [];
           directAwards.forEach(da => da.isDirectAward = true);
@@ -78,7 +80,7 @@
     }
     
     onMount(() => {
-        badgeClassIds = readBadgeClassIdsFromUrl();
+        initializeBadgeClassFilter();
         let validatedName = null;
         let directAwards = [];
         
@@ -108,28 +110,11 @@
         margin-bottom: 30px;
     }
 
-    .show-all-link {
-        font-size: 14px;
-        margin-top: 6px;
-        margin-left: 1em;
-        text-decoration: none;
-        color: var(--purple);
-        
-        &:hover {
-            text-decoration: underline;
-        }
-    }
-
 </style>
 
 <div>
     <div class="header">
         <h3>{I18n.t('backpack.title')}</h3>
-        {#if badgeClassIds.length > 0}
-            <a href="/backpack" use:link on:click={handleShowAllBadges} class="show-all-link">
-                {I18n.t('backpack.showAllBadges')}
-            </a>
-        {/if}
         <ViewSelector bind:view={view}/>
     </div>
     {#if showWelcome}


### PR DESCRIPTION
@ThomasKalverda : There was some pressure to release this. So I kept you as reviewer, but merged anyway. 
Please use this as informative, to learn about this weird filtering feature we have in feature/ewi. And feel free to comment or otherwise point out problems or possible improvements, so that I can apply those in a follow up PR.

In proeftuin, we need the ability to filter badgeInstances when linking to backpack from "Mijn HBOT" environment. We filter on "shared ids": Badge Classes are shared links.

We want this, to *simulate* (or fake) a behaviour where a remote system (proeftuin ecosystem) "adds badges to the backpack" once a user finishes an exam there. Since we don't have an API to add these badges for users, we chose to:
- Seed all users with all badges - As if they finished all exams.
- Add a filter to the backpack that allows the remote system to link to backpack and lets the user see only those badge-instances that they passed the exam for.

Previously, we had a system to make the filters visible to the user. On review, we wanted them hidden. And we wanted link to "backpack" or other links to not suddenly "unfilter" the badges - i.e. show te entire backpack.
We now hacked this in by setting the filter in localstorage.

This has the added benefit that it is "user-agent" bound: i.e. when John walks through the demo's they'll see different filters then when Jane walks through the demos.

- Removed `showAllBadges` translation keys from English and Dutch locales
- Removed unused `link` import from Svelte component
- Removed badge filtering state, URL parsing, and "show all" link
- Simplified badge fetching to always retrieve all badges
- Added persistent filter storage key constant (unused currently)

- Filter is stored in `localStorage`
- URL params (`filter.badgeclass_id`) take precedence over localStorage
- No UI to unset the filter (removed "show all badges" link)

| Scenario | URL | localStorage | filterBadgeClassIds used | Behavior | |----------|-----|--------------|--------------------------|----------| | First load with filter | `/backpack?filter.badgeclass_id=X` | empty | X | X is saved to localStorage |
| First load with multiple filters |
`/backpack?filter.badgeclass_id=X&filter.badgeclass_id=Y` | empty | [X, Y] | [X, Y] is saved to localStorage |
| In-app nav to `/backpack` | `/backpack` | [X, Y] | [X, Y] | Uses localStorage value |
| External load with different filter |
`/backpack?filter.badgeclass_id=Z` | [X, Y] | Z | Z overrides localStorage, saves to localStorage |
| External load no filter | `/backpack` | [Z] | [Z] | Uses localStorage value |
| External load no filter, no storage | `/backpack` | empty | [] | No filter applied |
| Direct load no filter | `/backpack` | empty | [] | No filter applied |

- **Persistence**: Once set via URL, filter remains active for all subsequent visits
- **Override**: URL params always override localStorage (allows filter updates)
- **No unset UI**: Users cannot remove the filter through the UI
- **Clean URLs**: In-app navigation uses `/backpack` without query params