### PR TITLE
Add wrongfully removed import statement back

### DIFF
--- a/src/components/teachers/badges/Assertions.svelte
+++ b/src/components/teachers/badges/Assertions.svelte
@@ -6,6 +6,7 @@
     import {Button, CheckBox} from "../../../components";
     import singleNeutralCheck from "../../../icons/single-neutral-check.svg";
     import {constructUserEmail, constructUserName} from "../../../util/users";
+    import {deleteDirectAwards, revokeAssertions} from "../../../api";
     import {searchMultiple} from "../../../util/searchData";
     import {Modal} from "../../forms";
     import {flash} from "../../../stores/flash";


### PR DESCRIPTION
This is a tiny bugfix to add a removed import statement back. This is what broke the revocation of direct awards/assertions.