### PR TITLE
Remove warning when entity form is a copy

### DIFF
--- a/src/components/teachers/BadgeclassForm.svelte
+++ b/src/components/teachers/BadgeclassForm.svelte
@@ -754,6 +754,7 @@
             cancelText={mayEdit ? I18n.t("newBadgeClassForm.saveAsDraft") : I18n.t("manage.edit.cancel")}
             submitText={(isCreate || badgeclass.isPrivate) ? I18n.t("newBadgeClassForm.publish") : I18n.t("manage.edit.save")}
             previewAction={() => doShowPreview()}
+            isCopy={isCopy}
             {processing}>
 
         <div class="form">
@@ -1336,4 +1337,3 @@
                             }
                             }/>
 {/if}
-

--- a/src/components/teachers/EntityForm.svelte
+++ b/src/components/teachers/EntityForm.svelte
@@ -17,6 +17,7 @@
     export let hasAnyAssertions;
     export let archived;
     export let mayEdit = true;
+    export let isCopy = false;
 
     export let create;
     export let cancel = () => window.history.back();
@@ -166,7 +167,7 @@
         </div>
     </div>
     <div class="warnings">
-        {#if mayDelete && hasUnrevokedAssertions}
+        {#if mayDelete && hasUnrevokedAssertions && !isCopy}
             <span class="may-not-delete">{I18n.t(`manage.delete.info.assertionsBlock.${entityTypeName}`)}</span>
         {:else if mayDelete && hasAnyAssertions && archived}
             <span class="may-not-delete">{I18n.t(`manage.archive.info.assertionsBlock.${entityTypeName}`)}</span>


### PR DESCRIPTION
This PR hacks a wrongfully shown warning away.

The EntityForm is a form that is used throughout the application for various things. I just added the `isCopy` prop that should only be set when copying a badge class. The warnings didn't take into account that it is possible to copy a badge class. Basically the copy badge class was treated as an 'edit', but it is actually a 'create' with pre filled fields. But I don't think it's worth it to refactor all of that now.