### PR TITLE
Allow save draft for copied badge classes

### DIFF
--- a/src/components/teachers/BadgeclassForm.svelte
+++ b/src/components/teachers/BadgeclassForm.svelte
@@ -749,9 +749,9 @@
             submit={onSubmit}
             create={isCreate}
             cancel={() => {
-                return mayEdit ? saveDraft() :  window.history.back()
+                return mayEdit || isCopy ? saveDraft() :  window.history.back()
             }}
-            cancelText={mayEdit ? I18n.t("newBadgeClassForm.saveAsDraft") : I18n.t("manage.edit.cancel")}
+            cancelText={mayEdit || isCopy ? I18n.t("newBadgeClassForm.saveAsDraft") : I18n.t("manage.edit.cancel")}
             submitText={(isCreate || badgeclass.isPrivate) ? I18n.t("newBadgeClassForm.publish") : I18n.t("manage.edit.save")}
             previewAction={() => doShowPreview()}
             {processing}>


### PR DESCRIPTION
This PR allows users to save a copied badge class as draft. 

Apparently the 'save as draft' button replaces the 'cancel' button on the create new badge form, so I added the 'isCopy' flag here as well. It's not robust at all, but it appears to work for now. Again, I don't want to refactor all the forms and logic, I don't think it's worth it at this point.