### PR TITLE
Using prod bool to determine whether to enable piwik

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -95,11 +95,13 @@ module.exports = {
             favicon: "src/favicon.ico",
             hash: true,
         }),
-        false ? new HtmlWebpackPartialsPlugin({
-            path: 'src/piwik.html',
-            location: 'head',
-            priority: 'low'
-        }) : false,
+        prod
+            ? new HtmlWebpackPartialsPlugin({
+                  path: "src/piwik.html",
+                  location: "head",
+                  priority: "low",
+              })
+            : false,
         // prod ? new BundleAnalyzerPlugin({
         //     analyzerMode: "disabled",
         //     generateStatsFile: false,


### PR DESCRIPTION
The `prod` variable refers to whether a production build is made or not, this does not refer to the deployment environment (e.g. acceptance/demo/staging/production).